### PR TITLE
Add explainable gating with debug output

### DIFF
--- a/configs/motifs.yaml
+++ b/configs/motifs.yaml
@@ -68,7 +68,7 @@ motifs:
       keep: 40
       candidate_stride: 1
       hit_eps_pct_range: [5, 25]
-      weight: 0.5
+      weight: 0.20
       freshness_bars: 12
     meso:
       L: 60
@@ -76,7 +76,7 @@ motifs:
       keep: 80
       candidate_stride: 1
       hit_eps_pct_range: [5, 25]
-      weight: 0.3
+      weight: 0.30
       freshness_bars: 15
     micro:
       L: 30
@@ -84,20 +84,20 @@ motifs:
       keep: 300
       candidate_stride: 1
       hit_eps_pct_range: [5, 25]
-      weight: 0.2
+      weight: 0.50
       freshness_bars: 5
 
 gating:
-  require_macro: true
+  require_macro: false       # macro banks were sparse; don't hard-require
   require_meso: true
   require_micro: true
   # start lenient so we actually place trades; tighten later
-  score_min: 0.60
+  score_min: 0.55            # was 0.60
   pick_side: "argmax"      # "argmax" | "macro_sign"
-  bad_max: 0.70            # max allowed composite from BAD bank
-  alpha: 0.15              # weight on BAD in (S_good - alpha* S_bad)
-  margin_min: 0.00         # minimum (S_good - alpha * S_bad)
-  discord_block_min: 0.99  # if any horizon discord score >= this, block
+  bad_max: 0.85              # was 0.70–0.75
+  alpha: 0.20                # more penalty on BAD
+  margin_min: -0.02          # allow near-ties initially
+  discord_block_min: 0.9995  # slightly less sensitive
   cooldown_bars: 20
 
 risk:

--- a/src/gating.py
+++ b/src/gating.py
@@ -1,0 +1,66 @@
+# src/gating.py
+from dataclasses import dataclass
+
+
+def composite_score(s_macro: float, s_meso: float, s_micro: float,
+                    w_macro: float = 0.20, w_meso: float = 0.30, w_micro: float = 0.50) -> float:
+    return w_macro * s_macro + w_meso * s_meso + w_micro * s_micro
+
+
+@dataclass
+class GateDecision:
+    ok: bool
+    reason: str
+    details: dict
+
+
+def passes_gate(Sg: dict, Sb: dict, discord: dict, cfg: dict, *, debug: bool = False) -> GateDecision:
+    """
+    Decide if we can place a trade given per-horizon GOOD/BAD scores.
+      Sg, Sb: dict like {"macro": 0.0..1.0, "meso": ..., "micro": ...}
+      discord: dict per horizon with 0.0..1.0 blocker score (higher = worse)
+      cfg: full YAML dict (needs motifs.horizons.*.weight and gating.*)
+    Returns GateDecision(ok, reason, details)
+    """
+    gcfg = cfg.get("gating", {})
+    wcfg = cfg.get("motifs", {}).get("horizons", {})
+    w = {
+        "macro": float(wcfg.get("macro", {}).get("weight", 0.20)),
+        "meso": float(wcfg.get("meso", {}).get("weight", 0.30)),
+        "micro": float(wcfg.get("micro", {}).get("weight", 0.50)),
+    }
+
+    # Horizon requirements
+    if gcfg.get("require_macro", False) and Sg.get("macro", 0.0) < gcfg.get("score_min", 0.6):
+        return GateDecision(False, "macro_req", {"Sg": Sg, "Sb": Sb})
+    if gcfg.get("require_meso", False) and Sg.get("meso", 0.0) < gcfg.get("score_min", 0.6):
+        return GateDecision(False, "meso_req", {"Sg": Sg, "Sb": Sb})
+    if gcfg.get("require_micro", False) and Sg.get("micro", 0.0) < gcfg.get("score_min", 0.6):
+        return GateDecision(False, "micro_req", {"Sg": Sg, "Sb": Sb})
+
+    # BAD veto
+    if max(Sb.get("macro", 0.0), Sb.get("meso", 0.0), Sb.get("micro", 0.0)) >= gcfg.get("bad_max", 0.8):
+        return GateDecision(False, "bad", {"Sg": Sg, "Sb": Sb})
+
+    # Composite score (weighted GOOD)
+    comp = composite_score(
+        Sg.get("macro", 0.0), Sg.get("meso", 0.0), Sg.get("micro", 0.0), **{
+            "w_macro": w["macro"], "w_meso": w["meso"], "w_micro": w["micro"],
+        }
+    )
+    if comp < gcfg.get("score_min", 0.6):
+        return GateDecision(False, "score", {"Sg": Sg, "Sb": Sb, "comp": comp})
+
+    # Margin gate: (best_good - alpha * best_bad) >= margin_min
+    best_good = max(Sg.values()) if Sg else 0.0
+    best_bad = max(Sb.values()) if Sb else 0.0
+    margin = best_good - gcfg.get("alpha", 0.15) * best_bad
+    if margin < gcfg.get("margin_min", 0.0):
+        return GateDecision(False, "margin", {"best_good": best_good, "best_bad": best_bad, "margin": margin})
+
+    # Discord block
+    if any(float(discord.get(h, 0.0)) >= gcfg.get("discord_block_min", 0.999) for h in ("macro", "meso", "micro")):
+        return GateDecision(False, "discord", {"discord": discord})
+
+    return GateDecision(True, "OK", {"Sg": Sg, "Sb": Sb, "comp": comp, "margin": margin})
+


### PR DESCRIPTION
## Summary
- Update motif horizon weights and gating thresholds for more flexible trade requirements
- Introduce `passes_gate` in new `src/gating.py` to provide explainable gate decisions
- Add simulation debug logging in `run_motifs.py` to trace accept/reject reasons per bar

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc805969a8832ba544b0fd8631ea70