### PR TITLE
Add trend-aware gating with horizon agreement

### DIFF
--- a/configs/motifs.yaml
+++ b/configs/motifs.yaml
@@ -76,7 +76,7 @@ motifs:
       keep: 80
       candidate_stride: 1
       hit_eps_pct_range: [5, 25]
-      weight: 0.40        # give meso more say
+      weight: 0.30
       freshness_bars: 15
     micro:
       L: 30
@@ -84,21 +84,32 @@ motifs:
       keep: 300
       candidate_stride: 1
       hit_eps_pct_range: [5, 25]
-      weight: 0.40        # take a little from micro
+      weight: 0.50
       freshness_bars: 5
 
 gating:
-  require_macro: false     # was true
-  require_meso:  true      # require alignment on meso
-  require_micro: true      # ...and micro
-  # match scores from MultiShapeletMatcher are typically ~0.05–0.30
-  score_min: 0.28          # tighter quality bar (was ~0.12–0.20)
-  pick_side: "argmax"
-  bad_max: 0.80            # earlier bad veto (was 0.95)
-  alpha: 0.30              # penalize BAD in margin more
-  margin_min: 0.02         # require positive (S_good - alpha*S_bad)
-  discord_block_min: 0.995
-  cooldown_bars: 120       # cut over-trading
+  # SIDE CONTROL (trend aligned)
+  pick_side: "macro_sign"        # long in macro-up regime, short in macro-down
+  long_only_if_macro_up:  true   # hard veto longs when macro is down
+  short_only_if_macro_dn: true   # hard veto shorts when macro is up
+
+  # HORIZON AGREEMENT
+  require_macro: false
+  require_meso:  false
+  require_micro: true
+  require_at_least_k_of: 2       # K-of-N horizons must clear their thresholds
+  score_min_per_horizon:         # per-horizon gates (meso typically scores lower)
+    macro: 0.10
+    meso:  0.10
+    micro: 0.22
+
+  # GLOBAL SELECTIVITY (composite + margin + BAD)
+  score_min: 0.28                # composite quality bar (weights above)
+  margin_min: 0.05               # require S_good - alpha * S_bad ≥ margin_min
+  alpha: 0.40                    # weight of BAD in margin
+  bad_max: 0.75                  # hard veto if any BAD(h) ≥ bad_max
+  discord_block_min: 0.995       # block if any horizon discord ≥ this
+  cooldown_bars: 180             # reduce clustering
 
 risk:
   sl_mult: 20.0
@@ -115,4 +126,4 @@ ui:
   progress: true
   progress_ascii: true
   progress_mininterval: 0.2
-  simulate_debug_first_n: 0   # 0 = don’t print per-minute decisions
+  simulate_debug_first_n: 0      # no per-bar spam; we print a summary per fold

--- a/src/gating.py
+++ b/src/gating.py
@@ -6,61 +6,89 @@ def composite_score(s_macro: float, s_meso: float, s_micro: float,
                     w_macro: float = 0.20, w_meso: float = 0.30, w_micro: float = 0.50) -> float:
     return w_macro * s_macro + w_meso * s_meso + w_micro * s_micro
 
-
 @dataclass
 class GateDecision:
     ok: bool
     reason: str
     details: dict
+    side: str | None = None
 
+def _thr_for(h: str, gcfg: dict) -> float:
+    per = gcfg.get("score_min_per_horizon", {}) or {}
+    return float(per.get(h, gcfg.get("score_min", 0.6)))
 
-def passes_gate(Sg: dict, Sb: dict, discord: dict, cfg: dict, *, debug: bool = False) -> GateDecision:
-    """
-    Decide if we can place a trade given per-horizon GOOD/BAD scores.
-      Sg, Sb: dict like {"macro": 0.0..1.0, "meso": ..., "micro": ...}
-      discord: dict per horizon with 0.0..1.0 blocker score (higher = worse)
-      cfg: full YAML dict (needs motifs.horizons.*.weight and gating.*)
-    Returns GateDecision(ok, reason, details)
-    """
+def _count_pass_horizons(Sg: dict, gcfg: dict) -> int:
+    return sum(float(Sg.get(h, 0.0)) >= _thr_for(h, gcfg) for h in ("macro","meso","micro"))
+
+def _trend_veto(side: str, macro_up: bool | None, gcfg: dict) -> tuple[bool,str]:
+    # Macro-sign pick (soft) and hard guards (long_only_if_macro_up / short_only_if_macro_dn)
+    if macro_up is None:
+        return (False, "")  # can't decide
+    if gcfg.get("pick_side", "argmax") == "macro_sign":
+        # If side disagrees with regime, block here.
+        if macro_up and side == "short":
+            return (True, "trend_guard")
+        if (not macro_up) and side == "long":
+            return (True, "trend_guard")
+    # Hard guards (independent of pick_side)
+    if gcfg.get("long_only_if_macro_up", False) and side == "long" and macro_up is False:
+        return (True, "trend_guard")
+    if gcfg.get("short_only_if_macro_dn", False) and side == "short" and macro_up is True:
+        return (True, "trend_guard")
+    return (False, "")
+
+def passes_gate(side: str,
+                Sg: dict,  # {"macro":float,"meso":float,"micro":float}
+                Sb: dict,  # {"macro":float,"meso":float,"micro":float}
+                discord: dict,  # {"macro":float,"meso":float,"micro":float}
+                cfg: dict,
+                *,
+                macro_up: bool | None = None) -> GateDecision:
     gcfg = cfg.get("gating", {})
     wcfg = cfg.get("motifs", {}).get("horizons", {})
     w = {
         "macro": float(wcfg.get("macro", {}).get("weight", 0.20)),
-        "meso": float(wcfg.get("meso", {}).get("weight", 0.30)),
+        "meso":  float(wcfg.get("meso",  {}).get("weight", 0.30)),
         "micro": float(wcfg.get("micro", {}).get("weight", 0.50)),
     }
 
-    # Horizon requirements
-    if gcfg.get("require_macro", False) and Sg.get("macro", 0.0) < gcfg.get("score_min", 0.6):
-        return GateDecision(False, "macro_req", {"Sg": Sg, "Sb": Sb})
-    if gcfg.get("require_meso", False) and Sg.get("meso", 0.0) < gcfg.get("score_min", 0.6):
-        return GateDecision(False, "meso_req", {"Sg": Sg, "Sb": Sb})
-    if gcfg.get("require_micro", False) and Sg.get("micro", 0.0) < gcfg.get("score_min", 0.6):
-        return GateDecision(False, "micro_req", {"Sg": Sg, "Sb": Sb})
+    # 0) Trend guard
+    veto, why = _trend_veto(side, macro_up, gcfg)
+    if veto:
+        return GateDecision(False, why, {"macro_up": macro_up}, side)
 
-    # BAD veto
-    if max(Sb.get("macro", 0.0), Sb.get("meso", 0.0), Sb.get("micro", 0.0)) >= gcfg.get("bad_max", 0.8):
-        return GateDecision(False, "bad", {"Sg": Sg, "Sb": Sb})
+    # 1) Hard per-horizon requirements
+    if gcfg.get("require_macro", False) and float(Sg.get("macro", 0.0)) < _thr_for("macro", gcfg):
+        return GateDecision(False, "macro_req", {"Sg": Sg}, side)
+    if gcfg.get("require_meso", False) and float(Sg.get("meso", 0.0))  < _thr_for("meso", gcfg):
+        return GateDecision(False, "meso_req", {"Sg": Sg}, side)
+    if gcfg.get("require_micro", False) and float(Sg.get("micro", 0.0)) < _thr_for("micro", gcfg):
+        return GateDecision(False, "micro_req", {"Sg": Sg}, side)
 
-    # Composite score (weighted GOOD)
-    comp = composite_score(
-        Sg.get("macro", 0.0), Sg.get("meso", 0.0), Sg.get("micro", 0.0), **{
-            "w_macro": w["macro"], "w_meso": w["meso"], "w_micro": w["micro"],
-        }
-    )
-    if comp < gcfg.get("score_min", 0.6):
-        return GateDecision(False, "score", {"Sg": Sg, "Sb": Sb, "comp": comp})
+    # 2) K-of-N horizon agreement
+    k_needed = int(gcfg.get("require_at_least_k_of", 0))
+    if k_needed > 0 and _count_pass_horizons(Sg, gcfg) < k_needed:
+        return GateDecision(False, "k_of_n", {"Sg": Sg, "k": k_needed}, side)
 
-    # Margin gate: (best_good - alpha * best_bad) >= margin_min
-    best_good = max(Sg.values()) if Sg else 0.0
-    best_bad = max(Sb.values()) if Sb else 0.0
-    margin = best_good - gcfg.get("alpha", 0.15) * best_bad
-    if margin < gcfg.get("margin_min", 0.0):
-        return GateDecision(False, "margin", {"best_good": best_good, "best_bad": best_bad, "margin": margin})
+    # 3) BAD hard veto
+    if max(float(Sb.get("macro",0.0)), float(Sb.get("meso",0.0)), float(Sb.get("micro",0.0))) >= float(gcfg.get("bad_max", 0.8)):
+        return GateDecision(False, "bad", {"Sb": Sb}, side)
 
-    # Discord block
-    if any(float(discord.get(h, 0.0)) >= gcfg.get("discord_block_min", 0.999) for h in ("macro", "meso", "micro")):
-        return GateDecision(False, "discord", {"discord": discord})
+    # 4) Composite quality (GOOD weighted)
+    comp = composite_score(float(Sg.get("macro",0.0)), float(Sg.get("meso",0.0)), float(Sg.get("micro",0.0)),
+                           w_macro=w["macro"], w_meso=w["meso"], w_micro=w["micro"])
+    if comp < float(gcfg.get("score_min", 0.6)):
+        return GateDecision(False, "score", {"comp": comp, "Sg": Sg}, side)
 
-    return GateDecision(True, "OK", {"Sg": Sg, "Sb": Sb, "comp": comp, "margin": margin})
+    # 5) Margin against BAD (favoring GOOD minus alpha * BAD)
+    best_good = max(float(Sg.get("macro",0.0)), float(Sg.get("meso",0.0)), float(Sg.get("micro",0.0)))
+    best_bad  = max(float(Sb.get("macro",0.0)), float(Sb.get("meso",0.0)), float(Sb.get("micro",0.0)))
+    margin = best_good - float(gcfg.get("alpha", 0.15)) * best_bad
+    if margin < float(gcfg.get("margin_min", 0.0)):
+        return GateDecision(False, "margin", {"best_good": best_good, "best_bad": best_bad, "margin": margin}, side)
 
+    # 6) Discord block
+    if any(float(discord.get(h, 0.0)) >= float(gcfg.get("discord_block_min", 0.999)) for h in ("macro","meso","micro")):
+        return GateDecision(False, "discord", {"discord": discord}, side)
+
+    return GateDecision(True, "OK", {"comp": comp, "margin": margin, "Sg": Sg, "Sb": Sb}, side)


### PR DESCRIPTION
## Summary
- tune motif horizon weights and replace gating configuration with trend-aware knobs
- implement unified gating module supporting trend alignment, K-of-N horizon checks, and BAD/margin vetoes
- pass macro regime to the gate in simulation and track detailed rejection reasons

## Testing
- `python -m py_compile src/gating.py run_motifs.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd418a26cc832bb15fb0d934581aaf